### PR TITLE
Rename category to categories in products.list()

### DIFF
--- a/content/en/basic-usage.md
+++ b/content/en/basic-usage.md
@@ -15,7 +15,7 @@ swell.init('my-store', 'pk_md0JkpLnp9gBjkQ085oiebb0XBuwqZX9')
 
 // Now you can use any method
 await swell.products.list({
-  category: 't-shirts',
+  categories: 't-shirts',
   limit: 25,
   page: 1
 })

--- a/content/en/products.md
+++ b/content/en/products.md
@@ -34,7 +34,7 @@ _Returns products in a specific category, with offset pagination using `limit` a
 
 ```javascript
 await swell.products.list({
-  category: 't-shirts', // Slug or ID
+  categories: 't-shirts', // Slug or ID
   limit: 25, // Max. 100
   page: 1
 })
@@ -94,7 +94,6 @@ const products = await swell.products.list(...)
 
 await swell.products.filters(products)
 ```
-
 
 <alert type="success">
 A filter list is based on the set of input products, therefore your page should retrieve the full set of relevant products before <a href="#apply-filters">applying filters</a>.


### PR DESCRIPTION
Using `category` as mentioned in the docs didn't return any product results, but `categories` does 👍